### PR TITLE
Use requests lib

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,58 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/

--- a/README.md
+++ b/README.md
@@ -5,27 +5,29 @@ Use the what3words API in your Python program (see http://developer.what3words.c
 
 ## Functions
 
-### getPosition(words=???)
+### position(words=???)
 This function takes the words parameter as either:
 - a string of 3 words `'table.book.chair'`
 - an array of 3 words `['table', 'book', 'chair']`
 
-### getWords(lat=???, lng=???)
+### words(lat=???, lng=???)
 This function takes the latitude and longitude:
 - 2 parameters:  `lat=0.1234`, `lng=1.5678`
 
 ## Code examples
 
+```from what3words import What3Words```
+
 ### Get position
 ```python
-w3w = what3words(apikey='YOURAPIKEY')
-res = w3w.getPosition(words='prom.cape.pump')
+w3w = What3Words(api_key='YOURAPIKEY')
+res = w3w.position(words='prom.cape.pump')
 print(res)
 ```
 
 ### Get 3 words
 ```python
-w3w = what3words(apikey='YOURAPIKEY')
-res = w3w.getWords(lat='51.484463', lng='-0.195405')
+w3w = what3words(api_key='YOURAPIKEY')
+res = w3w.words(lat='51.484463', lng='-0.195405')
 print(res)
 ```

--- a/__init.py__
+++ b/__init.py__
@@ -1,0 +1,1 @@
+from what3words import What3Words

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal=1

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,31 @@
+from setuptools import setup, find_packages
+
+from what3words import __version__
+
+
+setup(
+    name='what3words',
+    version='.'.join([str(x) for x in __version__]),
+    author='What3Words',
+    author_email='support@what3words.com',
+    url='https://github.com/what3words/w3w-python-wrapper',
+    description='What3words API library',
+    license='MIT',
+    packages=find_packages(),
+    install_requires=['six'],
+    classifiers=(
+        'Development Status :: 3 - Alpha',
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: MIT License',
+        'Operating System :: OS Independent',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2.6',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.2',
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: Implementation :: PyPy',
+        'Topic :: Software Development :: Libraries',
+    ),
+)

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     description='What3words API library',
     license='MIT',
     packages=find_packages(),
-    install_requires=['six'],
+    install_requires=['requests'],
     classifiers=(
         'Development Status :: 3 - Alpha',
         'Intended Audience :: Developers',

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup, find_packages
+from setuptools import setup
 
 from what3words import __version__
 
@@ -11,7 +11,7 @@ setup(
     url='https://github.com/what3words/w3w-python-wrapper',
     description='What3words API library',
     license='MIT',
-    packages=find_packages(),
+    py_modules=['what3words'],
     install_requires=['requests'],
     classifiers=(
         'Development Status :: 3 - Alpha',

--- a/what3words.py
+++ b/what3words.py
@@ -1,8 +1,7 @@
 import json
 
-from six.moves.urllib.request import urlopen
-from six.moves.urllib.parse import urljoin, urlencode
-
+from requests.compat import urljoin
+import requests
 
 __all__ = ('__version__', 'What3Words')
 
@@ -90,9 +89,8 @@ class What3Words(object):
         params.update({
             'key': self.api_key,
         })
-
         url = urljoin(self.host, url_path)
-
-        response = urlopen(url, urlencode(params)).read()
-
+        r = requests.get(url, params=params)
+        response = r.text
         return json.loads(response)
+


### PR DESCRIPTION
Sorry to add another PR while the former one is still pending, but I wanted to have this at least in my own fork, and it seemed to me a worthy contribution as well. This commit includes the `setup.py` and other changes from @svartalf, plus also replaces the `six.moves.urllib` with the [Requests](http://docs.python-requests.org/en/latest/) module. Requests is not only sexier (i.e. more modern and humane) but also addresses an issue I have been experiencing where I was getting intermittent "Missing or invalid key" errors from the urllib-driven request. As I was passing a key that I could verify using `curl` against the API, I'm not clear what was actually going on there, but I haven't seen it since switching to Requests.

If this seems worthy, you may just want to merge this one and skip #2, but I leave that to your discretion.

Thanks for the great geocoding system and for your consideration.